### PR TITLE
feat(gateway): allow sending messages to specific users

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,18 +108,21 @@ wss.on("connection", function connection(ws: ChatClient, req) {
         })
     );
 
-    setInterval(() => {
-        if (ws.lastHeartbeat + 10000 < Date.now()) {
-            ws.close();
-        } else {
-            ws.send(
-                JSON.stringify({
-                    op: 2,
-                    d: {}
-                })
-            );
-        }
-    }, Math.floor(Math.random() * 10000) + 1000);
+    setInterval(
+        () => {
+            if (ws.lastHeartbeat + 10000 < Date.now()) {
+                ws.close();
+            } else {
+                ws.send(
+                    JSON.stringify({
+                        op: 2,
+                        d: {}
+                    })
+                );
+            }
+        },
+        Math.floor(Math.random() * 10000) + 1000
+    );
 });
 
 initIPC();

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,21 +1,23 @@
 import { WebSocket } from "ws";
 
-export const Role = {
-    Guest: 1 << 0,
-    User: 1 << 1,
-    Bot: 1 << 2,
-    System: 1 << 3,
-    Mod: 1 << 4,
-    Admin: 1 << 5
-};
+export const enum Role {
+    Guest = 1 << 0,
+    User = 1 << 1,
+    Bot = 1 << 2,
+    System = 1 << 3,
+    Mod = 1 << 4,
+    Admin = 1 << 5
+}
 
-export const MessageTypes = {
-    Normal: 0,
-    Join: 1,
-    Leave: 2,
-    GoodPerson: 3,
-    Bridge: 4
-};
+export const enum MessageTypes {
+    Normal = 0,
+    Join = 1,
+    Leave = 2,
+    GoodPerson = 3,
+    Bridge = 4,
+    IncomingDM,
+    OutgoingDM // NOTE(PoolloverNathan): these are currently sent to clients as if the *recipient* sent the message, for backwards-compatibility
+}
 
 export interface ChatClient extends WebSocket {
     ipAddress: string;


### PR DESCRIPTION
This allows clients to specify the `dmTo` field in messages. This should be the user ID of a connected user (if there are no matches, the message will be refused with an error). If this is specified, the message will not be saved to history, and it will be sent only to connections belonging to the specified user.
