### PR TITLE
feat(gateway): convert rules to use actual regex

### DIFF
--- a/src/modules/moderate.ts
+++ b/src/modules/moderate.ts
@@ -48,56 +48,43 @@ const badNounsReplacements = [
     "32gb Trident Z @3200",
     "ultrakill"
 ];
-const bannedWords = [
-    "cunt",
-    "whore",
-    "pussy",
-    "slut",
-    "tit",
-    "cum",
-    "blowjob",
-    "bewbs",
-    "boob",
-    "booba",
-    "boobies",
-    "boobs",
-    "booby",
-    "porn",
-    "pron",
-    "pawrn",
-    "r34",
-    "rule34",
-    "mewing", // 🤫🧏🏻‍♂️
-    "mew",
-    "skibidi", // 🚽
-    "gyat",
-    "gyatt",
-    "rizzler",
-    "nettspend",
-    "boykisser",
-    "rizz",
-    "hawk tuah",
-    "retard",
-    "faggot",
-    "fag", // hey look it's us - koda and zander
-    "faggots",
-    "fags",
-    "n*g",
-    "n*gg*",
-    "n*gg*r",
-    "nigga",
-    "grope",
-    "tranny" // haha also me - zander
+
+// WARN: All entries in this array must be regexes. All regexes will have /gu applied to them — manually-specified flags will be ignored!
+const bannedWords: RegExp[] = [
+    /cunt/,
+    /whore/,
+    /puss(?:y?|ies?)/,
+    /slut/,
+    /tit/,
+    /cum/,
+    /blowjob/,
+    /b(?:oo|ew)b.+/,
+    /porn/,
+    /pron/,
+    /pawrn/,
+    /r(?:ule)?\s*34/,
+    /meo?w\w+/,
+    /skibidi/, // 🚽
+    /gyat+/,
+    /rizzler/,
+    /nettspend/,
+    /boykisser/,
+    /rizz+/,
+    /hawk\\s*tuah/,
+    /retard/,
+    /fag(?:g?ot)?s?/, // hey look it's us - koda and zander
+    /n[i\*]g(?:g?[ae])?r?/,
+    /grope/,
+    /tranny/ // haha also me - zander
 ];
 
 export function onlyLettersAndNumbers(string: string) {
     return string.match(/^[A-Za-z0-9]*$/);
 }
 
+const badWordsRegex = new RegExp("\\b(" + bannedWords.map(regex => regex.source).join("|") + ")\\b", "gi");
 function replaceBadWords(content: string): string {
-    const regex = new RegExp("\\b(" + bannedWords.join("|") + ")\\b", "gi");
-
-    return content.replace(regex, function (match) {
+    return content.replace(badWordsRegex, function (match) {
         const randomIndex = Math.floor(Math.random() * badNounsReplacements.length);
         return badNounsReplacements[randomIndex];
     });


### PR DESCRIPTION
`bannedWords` is now specified as a list of regexes. They are converted to their source when constructing the final pattern (flags do not work!). Additionally, `badWordsRegex` is now compiled ahead-of-time, since I found it easy and this saves performance (and will nearly never be overeager, since it's probable that at least one non-mod-admin will send a message per session)

BREAKING CHANGE: This adds more filtered words.

BREAKING CHANGE: If you rely on certain false positives being filtered (such as 'g'), they will no longer be filtered.
